### PR TITLE
fix multi_get

### DIFF
--- a/aiomcache/client.py
+++ b/aiomcache/client.py
@@ -115,7 +115,7 @@ class Client(object):
 
         if len(received) > len(keys):
             raise ClientException('received too many responses')
-        return [received.get(k) for k in keys if k in received]
+        return [received.get(k, None) for k in keys]
 
     @acquire
     def delete(self, conn, key):

--- a/tests/commands_test.py
+++ b/tests/commands_test.py
@@ -56,6 +56,8 @@ class ConnectionCommandsTest(BaseTest):
         yield from self.mcache.set(key, value)
         test_value = yield from self.mcache.get(key)
         self.assertEqual(test_value, value)
+        test_value = yield from self.mcache.get(b'not:' + key)
+        self.assertEqual(test_value, None)
 
         with patch.object(self.mcache, '_execute_simple_command') as patched, \
                 self.assertRaises(ClientException):
@@ -75,6 +77,8 @@ class ConnectionCommandsTest(BaseTest):
         test_value = yield from self.mcache.multi_get(key1, key2)
         self.assertEqual(test_value, [value1, value2])
 
+        test_value = yield from self.mcache.multi_get(b'not' + key1, key2)
+        self.assertEqual(test_value, [None, value2])
         test_value = yield from self.mcache.multi_get()
         self.assertEqual(test_value, [])
 


### PR DESCRIPTION
`multi_get` does not work properly, if _value_ does not exists for specified _key_, client simply omits value.
`None` should be returned in this case.
