### PR TITLE
Add support for python 3.5's `await`.

### DIFF
--- a/aiomcache/client.py
+++ b/aiomcache/client.py
@@ -12,6 +12,7 @@ __all__ = ['Client']
 
 def acquire(func):
 
+    @asyncio.coroutine
     @functools.wraps(func)
     def wrapper(self, *args, **kwargs):
         conn = yield from self._pool.acquire()


### PR DESCRIPTION
When you're using `await mc.set(b'some_key', b'some_value')` you get a `TypeError: 'generator' object is not callable`.

This PR fixes that.