### PR TITLE
Reduced duplicated code after gets/cas code merge

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ test: flake
 
 
 cov cover coverage: flake
-	py.test --cov=aiomcache --cov-report=html --cov-report=term tests
+	py.test --cov=aiomcache --cov-report=html --cov-report=term-missing tests
 	@echo "open file://`pwd`/htmlcov/index.html"
 
 

--- a/aiomcache/client.py
+++ b/aiomcache/client.py
@@ -171,7 +171,7 @@ class Client(object):
         and socket errors
         """
         values, _ = yield from self._multi_get(conn, *keys)
-        return [values.get(key) for key in keys]
+        return (values.get(key) for key in keys)
 
     @acquire
     def stats(self, conn, args=None):

--- a/aiomcache/client.py
+++ b/aiomcache/client.py
@@ -171,7 +171,7 @@ class Client(object):
         and socket errors
         """
         values, _ = yield from self._multi_get(conn, *keys)
-        return (values.get(key) for key in keys)
+        return [values.get(key) for key in keys]
 
     @acquire
     def stats(self, conn, args=None):

--- a/aiomcache/client.py
+++ b/aiomcache/client.py
@@ -171,7 +171,7 @@ class Client(object):
         and socket errors
         """
         values, _ = yield from self._multi_get(conn, *keys)
-        return [values.get(key) for key in keys]
+        return tuple(values.get(key) for key in keys)
 
     @acquire
     def stats(self, conn, args=None):

--- a/tests/commands_test.py
+++ b/tests/commands_test.py
@@ -84,12 +84,12 @@ def test_multi_get(mcache):
     yield from mcache.set(key1, value1)
     yield from mcache.set(key2, value2)
     test_value = yield from mcache.multi_get(key1, key2)
-    assert test_value == [value1, value2]
+    assert test_value == (value1, value2)
 
     test_value = yield from mcache.multi_get(b'not' + key1, key2)
-    assert test_value == [None, value2]
+    assert test_value == (None, value2)
     test_value = yield from mcache.multi_get()
-    assert test_value == []
+    assert test_value == ()
 
 
 @pytest.mark.run_loop


### PR DESCRIPTION
After introducing gets/cas commands, multi_get function code was somehow duplicated. With this MR both functions are merged to only one.