### PR TITLE
Add pytest option for non-docker memcached & trivial fixes

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,8 +9,7 @@ import sys
 import time
 import uuid
 import warnings
-
-from docker import Client as DockerClient
+import docker as docker_mod
 
 import memcache
 import aiomcache
@@ -232,7 +231,7 @@ def session_id():
 
 @pytest.fixture(scope='session')
 def docker():
-    return DockerClient(version='auto')
+    return docker_mod.from_env()
 
 
 def mcache_server_actual(host, port='11211'):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -245,9 +245,9 @@ def mcache_server_actual(host, port='11211'):
 
 
 def mcache_server_docker(unused_port, docker, session_id):
-    docker.pull('memcached:latest')
+    docker.pull('memcached:alpine')
     container = docker.create_container(
-        image='memcached',
+        image='memcached:alpine',
         name='memcached-test-server-{}'.format(session_id),
         ports=[11211],
         detach=True,


### PR DESCRIPTION
- Add pytest option for non-docker memcached
- The test will not wait 5 seconds for memcached connection.
- The memcached docker container will be stopped and removed regardless of failure in test