### PR TITLE
WIP use deque instead of asyncio.Queue

### DIFF
--- a/aiomcache/pool.py
+++ b/aiomcache/pool.py
@@ -39,12 +39,9 @@ class MemcachePool:
         """
         while self.size() < self._minsize:
             _conn = yield from self._create_new_conn()
-
-            # Could not create new connection
             if _conn is None:
                 break
-            if self.size() < self._minsize:
-                self._pool.append(_conn)
+            self._pool.append(_conn)
 
         conn = None
         while not conn:
@@ -84,7 +81,12 @@ class MemcachePool:
                     self._host, self._port, loop=self._loop)
             except:
                 raise
-            return _connection(reader, writer)
+            if self.size() < self._maxsize:
+                return _connection(reader, writer)
+            else:
+                reader.feed_eof()
+                writer.close()
+                return None
         else:
             return None
 

--- a/tests/pool_test.py
+++ b/tests/pool_test.py
@@ -27,7 +27,7 @@ def test_pool_acquire_release2(mcache_params, loop):
     writer.close()
     reader.feed_eof()
     conn = _connection(reader, writer)
-    yield from pool._pool.put(conn)
+    pool._pool.append(conn)
     conn = yield from pool.acquire()
     assert isinstance(conn.reader, asyncio.StreamReader)
     assert isinstance(conn.writer, asyncio.StreamWriter)
@@ -40,7 +40,7 @@ def test_pool_clear(mcache_params, loop):
     pool.release(conn)
     assert pool.size() == 1
     yield from pool.clear()
-    assert pool._pool.qsize() == 0
+    assert len(pool._pool) == 0
 
 
 @pytest.mark.run_loop
@@ -51,7 +51,7 @@ def test_acquire_dont_create_new_connection_if_have_conn_in_pool(mcache_params,
 
     # Add a valid connection
     _conn = yield from pool._create_new_conn()
-    yield from pool._pool.put(_conn)
+    pool._pool.append(_conn)
     assert pool.size() == 1
 
     conn = yield from pool.acquire()
@@ -77,7 +77,7 @@ def test_acquire_limit_maxsize(mcache_params,
         yield from asyncio.sleep(0.01, loop=loop)
         assert len(pool._in_use) == 1
         assert pool.size() == 1
-        assert pool._pool.qsize() == 0
+        assert len(pool._pool) == 0
         pool.release(conn)
 
     yield from asyncio.gather(*([acquire_wait_release()] * 3), loop=loop)

--- a/tests/pool_test.py
+++ b/tests/pool_test.py
@@ -85,7 +85,7 @@ def test_acquire_limit_maxsize(mcache_params,
     yield from asyncio.gather(*([acquire_wait_release()] * 50), loop=loop)
     assert pool.size() == 1
     assert len(pool._in_use) == 0
-    assert pool._pool.qsize() == 1
+    assert len(pool._pool) == 1
 
 
 @pytest.mark.run_loop
@@ -103,6 +103,7 @@ def test_acquire_task_cancellation(
             assert self._pool.size() == 1
             assert len(self._pool._in_use) == 1
             yield from asyncio.sleep(random.uniform(0.01, 0.02), loop=loop)
+            assert self._pool.size() == 1
 
     client = Client()
     _conn = yield from client._pool.acquire()
@@ -111,12 +112,10 @@ def test_acquire_task_cancellation(
     tasks = [
         asyncio.wait_for(
             client.acquire_wait_release(),
-            random.uniform(1, 2), loop=loop) for x in range(3550)
+            random.uniform(1, 2), loop=loop) for x in range(400)
     ]
-    results = yield from asyncio.gather(*tasks, loop=loop, return_exceptions=True)
-    import ipdb; ipdb.set_trace()
+    yield from asyncio.gather(*tasks, loop=loop, return_exceptions=True)
     assert len(client._pool._in_use) == 0
-    yield from client.acquire_wait_release()
 
 
 @pytest.mark.run_loop


### PR DESCRIPTION
The MR fixes #43 (related https://github.com/argaen/aiocache/issues/196)

Deque doesn't have context switches for the coroutines and makes the flow of acquiring connection more atomic.

Script I've been using to test:

```python
import uuid
import logging
import asyncio
import aiomcache

from aiohttp import web

logger = logging.getLogger(__name__)


class CacheManager:
    def __init__(self):
        self.cache = aiomcache.Client("127.0.0.1", 11211, pool_size=4)

    async def get(self, key):
        return await asyncio.wait_for(self.cache.get(key), 0.1)

    async def set(self, key, value):
        return await asyncio.wait_for(self.cache.set(key, value), 0.1)


async def handler_get(req):
    try:
        data = await req.app['cache'].get(b'testkey')
        print("Pool:" + str(len(req.app['cache'].cache._pool._pool)))
        print("Use:" + str(len(req.app['cache'].cache._pool._in_use)))
        if data:
            return web.Response(text=data.decode())
        data = str(uuid.uuid4()).encode()
        await req.app['cache'].set(b'testkey', data)
        return web.Response(text=str(data))
    except asyncio.TimeoutError:
        data = str(uuid.uuid4()).encode()
        await req.app['cache'].set(b'testkey', data)
        return web.Response(status=404)


if __name__ == '__main__':
    app = web.Application()
    app['cache'] = CacheManager()
    app.router.add_route('GET', '/', handler_get)
    web.run_app(app)
```

Do the load testing with: `ab -n 3500 -c 1000 http://127.0.0.1:8080/`.

To see the difference, change to master and repeat the load test. You can observe the server crashes and never recovers (plus the amount of errors is huge).

cc @fafhrd91 @achedeuzot I would like you to do the same tests to double check :)