### PR TITLE
add default keyword argument to multi_get()

### DIFF
--- a/aiomcache/client.py
+++ b/aiomcache/client.py
@@ -162,7 +162,7 @@ class Client(object):
         return values.get(key, default), cas_tokens.get(key)
 
     @acquire
-    def multi_get(self, conn, *keys):
+    def multi_get(self, conn, *keys, default=None):
         """Takes a list of keys and returns a list of values.
 
         :param keys: ``list`` keys for the item being fetched.
@@ -171,7 +171,7 @@ class Client(object):
         and socket errors
         """
         values, _ = yield from self._multi_get(conn, *keys)
-        return tuple(values.get(key) for key in keys)
+        return tuple(values.get(key, default) for key in keys)
 
     @acquire
     def stats(self, conn, args=None):

--- a/tests/commands_test.py
+++ b/tests/commands_test.py
@@ -88,7 +88,16 @@ def test_multi_get(mcache):
 
     test_value = yield from mcache.multi_get(b'not' + key1, key2)
     assert test_value == (None, value2)
+
+    test_value = yield from mcache.multi_get(b'not' + key1,
+                                             key2,
+                                             default=value1)
+    assert test_value == (value1, value2)
+
     test_value = yield from mcache.multi_get()
+    assert test_value == ()
+
+    test_value = yield from mcache.multi_get(default=value1)
     assert test_value == ()
 
 


### PR DESCRIPTION
Similar to get() and gets(), it would be useful to be able to specify a default value for missing keys in multi_get().