### PR TITLE
update _valid_key_re

### DIFF
--- a/aiomcache/client.py
+++ b/aiomcache/client.py
@@ -39,7 +39,7 @@ class Client(object):
     # key supports ascii sans space and control chars
     # \x21 is !, right after space, and \x7e is -, right before DEL
     # also 1 <= len <= 250 as per the spec
-    _valid_key_re = re.compile(b'^[\x21-\x7e]{1,250}$')
+    _valid_key_re = re.compile(b'^[^\x00-\x20\x7f]{1,250}$')
 
     def _validate_key(self, key):
         if not isinstance(key, bytes):  # avoid bugs subtle and otherwise


### PR DESCRIPTION
ref: https://github.com/aio-libs/aiomcache/issues/118

Is it more appropriate to use this?

```python
In [8]: _valid_key_re = re.compile(b'^[^\x00-\x20\x7f]{1,250}$')                                                  

In [9]: _valid_key_re.match(b'123')                                                                               
Out[9]: <_sre.SRE_Match object; span=(0, 3), match=b'123'>

In [10]: _valid_key_re.match(b'abc')                                                                               
Out[10]: <_sre.SRE_Match object; span=(0, 3), match=b'abc'>

In [11]: _valid_key_re.match(bytes('中文', 'utf-8'))                                                               
Out[11]: <_sre.SRE_Match object; span=(0, 6), match=b'\xe4\xb8\xad\xe6\x96\x87'>

In [12]: _valid_key_re.match(bytes('こんにちは', 'utf-8'))                                                         
Out[12]: <_sre.SRE_Match object; span=(0, 15), match=b'\xe3\x81\x93\xe3\x82\x93\xe3\x81\xab\xe3\x81\xa1>

In [13]: _valid_key_re.match(bytes('안녕하세요', 'utf-8'))                                                         
Out[13]: <_sre.SRE_Match object; span=(0, 15), match=b'\xec\x95\x88\xeb\x85\x95\xed\x95\x98\xec\x84\xb8>

In [14]: _valid_key_re.match(b' ')      

In [15]: _valid_key_re.match(bytes('!@#', 'utf-8'))                                                                
Out[15]: <_sre.SRE_Match object; span=(0, 3), match=b'!@#'>
```