### PR TITLE
Added support for connecting via unix socket

### DIFF
--- a/aiomcache/client.py
+++ b/aiomcache/client.py
@@ -28,13 +28,10 @@ def acquire(func):
 
 
 class Client(object):
-
-    def __init__(self, host, port=11211, *,
-                 pool_size=2, pool_minsize=None, loop=None):
+    def __init__(self, host='127.0.0.1', port=11211, *, pool_size=2, pool_minsize=None, loop=None, unix='/tmp/memcached.sock'):
         if not pool_minsize:
             pool_minsize = pool_size
-        self._pool = MemcachePool(
-            host, port, minsize=pool_minsize, maxsize=pool_size, loop=loop)
+        self._pool = MemcachePool(host, port, minsize=pool_minsize, maxsize=pool_size, loop=loop, unix=unix)
 
     # key supports ascii sans space and control chars
     # \x21 is !, right after space, and \x7e is -, right before DEL


### PR DESCRIPTION
These changes do not violate the old code, but complement it
Unix socket connection is 30% faster than TCP
Now, if there is a file along the path /tmp/memcached.sock, then a unix connection is selected
I think this change will help other developers who need a Unix connection.