### PR TITLE
Enable TLS protected connections to memcache

### DIFF
--- a/aiomcache/client.py
+++ b/aiomcache/client.py
@@ -1,8 +1,8 @@
 import functools
 import re
 import sys
-from typing import (Any, Awaitable, Callable, Dict, Generic, Optional, Tuple, TypeVar,
-                    Union, overload)
+from typing import (Any, Awaitable, Callable, Dict, Generic, Mapping, Optional, Tuple,
+                    TypeVar, Union, overload)
 
 from . import constants as const
 from .exceptions import ClientException, ValidationException
@@ -52,7 +52,7 @@ def acquire(
 class FlagClient(Generic[_T]):
     def __init__(self, host: str, port: int = 11211, *,
                  pool_size: int = 2, pool_minsize: Optional[int] = None,
-                 conn_args: Optional[Dict[str, Any]] = None,
+                 conn_args: Optional[Mapping[str, Any]] = None,
                  get_flag_handler: Optional[_GetFlagHandler[_T]] = None,
                  set_flag_handler: Optional[_SetFlagHandler[_T]] = None):
         """
@@ -499,7 +499,7 @@ class FlagClient(Generic[_T]):
 class Client(FlagClient[bytes]):
     def __init__(self, host: str, port: int = 11211, *,
                  pool_size: int = 2, pool_minsize: Optional[int] = None,
-                 conn_args: Optional[Dict[str, Any]] = None):
+                 conn_args: Optional[Mapping[str, Any]] = None):
         super().__init__(host, port, pool_size=pool_size, pool_minsize=pool_minsize,
                          conn_args=conn_args,
                          get_flag_handler=None, set_flag_handler=None)

--- a/aiomcache/client.py
+++ b/aiomcache/client.py
@@ -53,8 +53,8 @@ def acquire(
 class FlagClient(Generic[_T]):
     def __init__(self, host: str, port: int = 11211, *,
                  pool_size: int = 2, pool_minsize: Optional[int] = None,
-                 ssl: Union[bool, SSLContext] = False,
-                 ssl_handshake_timeout: Union[float, None] = None,
+                 ssl: Optional[Union[bool, SSLContext]] = None,
+                 ssl_handshake_timeout: Optional[float] = None,
                  get_flag_handler: Optional[_GetFlagHandler[_T]] = None,
                  set_flag_handler: Optional[_SetFlagHandler[_T]] = None):
         """
@@ -67,9 +67,15 @@ class FlagClient(Generic[_T]):
         :param ssl: whether to use TLS against the memcache server. If ssl
             is a ssl.SSLContext object, this context is used to create the
             transport; if ssl is True, a default context returned from
-            ssl.create_default_context() is used
+            ssl.create_default_context() is used. This parameter is sent
+            through to asyncio.create_connection(), so see
+            https://docs.python.org/3/library/asyncio-eventloop.html#asyncio.loop.create_connection
+            for a detailed description.
         :param ssl_handshake_timeout: time in seconds to wait for the TLS
-            handshake to complete, if using TLS
+            handshake to complete, if using TLS. This parameter is sent
+            through to asyncio.create_connection(), so see
+            https://docs.python.org/3/library/asyncio-eventloop.html#asyncio.loop.create_connection
+            for a detailed description.
         :param get_flag_handler: async method to call to convert flagged
             values. Method takes tuple: (value, flags) and should return
             processed value or raise ClientException if not supported.
@@ -81,8 +87,8 @@ class FlagClient(Generic[_T]):
             pool_minsize = pool_size
 
         self._pool = MemcachePool(
-            host, port, minsize=pool_minsize, maxsize=pool_size, ssl=ssl,
-            ssl_handshake_timeout=ssl_handshake_timeout)
+            host, port, minsize=pool_minsize, maxsize=pool_size,
+            ssl=ssl, ssl_handshake_timeout=ssl_handshake_timeout)
 
         self._get_flag_handler = get_flag_handler
         self._set_flag_handler = set_flag_handler
@@ -504,8 +510,8 @@ class FlagClient(Generic[_T]):
 class Client(FlagClient[bytes]):
     def __init__(self, host: str, port: int = 11211, *,
                  pool_size: int = 2, pool_minsize: Optional[int] = None,
-                 ssl: Union[bool, SSLContext] = False,
-                 ssl_handshake_timeout: Union[float, None] = None):
+                 ssl: Optional[Union[bool, SSLContext]] = None,
+                 ssl_handshake_timeout: Optional[float] = None):
         super().__init__(host, port, pool_size=pool_size, pool_minsize=pool_minsize,
                          ssl=ssl, ssl_handshake_timeout=ssl_handshake_timeout,
                          get_flag_handler=None, set_flag_handler=None)

--- a/aiomcache/pool.py
+++ b/aiomcache/pool.py
@@ -1,5 +1,5 @@
 import asyncio
-from typing import Any, Dict, NamedTuple, Optional, Set
+from typing import Any, Mapping, NamedTuple, Optional, Set
 
 __all__ = ['MemcachePool']
 
@@ -11,7 +11,7 @@ class Connection(NamedTuple):
 
 class MemcachePool:
     def __init__(self, host: str, port: int, *, minsize: int, maxsize: int,
-                 conn_args: Optional[Dict[str, Any]] = None):
+                 conn_args: Optional[Mapping[str, Any]] = None):
         self._host = host
         self._port = port
         self._minsize = minsize

--- a/aiomcache/pool.py
+++ b/aiomcache/pool.py
@@ -12,8 +12,8 @@ class Connection(NamedTuple):
 
 class MemcachePool:
     def __init__(self, host: str, port: int, *, minsize: int, maxsize: int,
-                 ssl: Union[bool, SSLContext] = False,
-                 ssl_handshake_timeout: Union[float, None] = None):
+                 ssl: Optional[Union[bool, SSLContext]] = None,
+                 ssl_handshake_timeout: Optional[float] = None):
         self._host = host
         self._port = port
         self._minsize = minsize

--- a/tests/conn_args_test.py
+++ b/tests/conn_args_test.py
@@ -10,8 +10,10 @@ from .conftest import McacheParams
 
 
 @pytest.mark.skipif(sys.version_info < (3, 8), reason="AsyncMock requires python3.8")
-async def test_ssl_params_forwarded_from_client() -> None:
-    client = Client("host", port=11211, ssl=True, ssl_handshake_timeout=20)
+async def test_params_forwarded_from_client() -> None:
+    client = Client("host", port=11211, conn_args={
+        "ssl": True, "ssl_handshake_timeout": 20
+    })
 
     with mock.patch(
         "asyncio.open_connection",
@@ -29,7 +31,7 @@ async def test_ssl_params_forwarded_from_client() -> None:
 async def test_ssl_client_fails_against_plaintext_server(
     mcache_params: McacheParams,
 ) -> None:
-    client = Client(**mcache_params, ssl=True)
+    client = Client(**mcache_params, conn_args={"ssl": True})
     # If SSL was correctly enabled, this should
     # fail, since SSL isn't enabled on the memcache
     # server.

--- a/tests/pool_test.py
+++ b/tests/pool_test.py
@@ -134,6 +134,7 @@ async def test_maxsize_greater_than_minsize(mcache_params: McacheParams) -> None
     assert isinstance(conn.reader, asyncio.StreamReader)
     assert isinstance(conn.writer, asyncio.StreamWriter)
     pool.release(conn)
+    await pool.clear()
 
 
 @pytest.mark.asyncio
@@ -143,6 +144,7 @@ async def test_0_minsize(mcache_params: McacheParams) -> None:
     assert isinstance(conn.reader, asyncio.StreamReader)
     assert isinstance(conn.writer, asyncio.StreamWriter)
     pool.release(conn)
+    await pool.clear()
 
 
 @pytest.mark.asyncio

--- a/tests/ssl_test.py
+++ b/tests/ssl_test.py
@@ -1,28 +1,36 @@
+import ssl
+import sys
+from asyncio import StreamReader, StreamWriter
 from unittest import mock
-from unittest.mock import MagicMock
 
 import pytest
-import ssl
+
 from aiomcache import Client
 from .conftest import McacheParams
 
 
-@pytest.mark.asyncio
+@pytest.mark.skipif(sys.version_info < (3, 8), reason="AsyncMock requires python3.8")
 async def test_ssl_params_forwarded_from_client() -> None:
-        client = Client("host", port=11211, ssl=True, ssl_handshake_timeout=20)
+    client = Client("host", port=11211, ssl=True, ssl_handshake_timeout=20)
 
-        with mock.patch("asyncio.open_connection", return_value=(MagicMock, MagicMock)) as oc:
-            await client._pool._create_new_conn()
+    with mock.patch(
+        "asyncio.open_connection",
+        return_value=(
+            mock.create_autospec(StreamReader),
+            mock.create_autospec(StreamWriter),
+        ),
+    ) as oc:
+        await client._pool.acquire()
 
-        oc.assert_called_once_with("host", 11211, ssl=True, ssl_handshake_timeout=20)
+    oc.assert_called_with("host", 11211, ssl=True, ssl_handshake_timeout=20)
 
-@pytest.mark.asyncio
+
 async def test_ssl_client_fails_against_plaintext_server(
-    mcache_params: McacheParams
+    mcache_params: McacheParams,
 ) -> None:
-        client = Client(**mcache_params, ssl=True)
-        # If SSL was correctly enabled, this should
-        # fail, since SSL isn't enabled on the memcache
-        # server.
-        with pytest.raises(ssl.SSLError):
-            await client.get(b"key")
+    client = Client(**mcache_params, ssl=True)
+    # If SSL was correctly enabled, this should
+    # fail, since SSL isn't enabled on the memcache
+    # server.
+    with pytest.raises(ssl.SSLError):
+        await client.get(b"key")

--- a/tests/ssl_test.py
+++ b/tests/ssl_test.py
@@ -19,6 +19,7 @@ async def test_ssl_params_forwarded_from_client() -> None:
             mock.create_autospec(StreamReader),
             mock.create_autospec(StreamWriter),
         ),
+        autospec=True,
     ) as oc:
         await client._pool.acquire()
 

--- a/tests/ssl_test.py
+++ b/tests/ssl_test.py
@@ -1,0 +1,28 @@
+from unittest import mock
+from unittest.mock import MagicMock
+
+import pytest
+import ssl
+from aiomcache import Client
+from .conftest import McacheParams
+
+
+@pytest.mark.asyncio
+async def test_ssl_params_forwarded_from_client() -> None:
+        client = Client("host", port=11211, ssl=True, ssl_handshake_timeout=20)
+
+        with mock.patch("asyncio.open_connection", return_value=(MagicMock, MagicMock)) as oc:
+            await client._pool._create_new_conn()
+
+        oc.assert_called_once_with("host", 11211, ssl=True, ssl_handshake_timeout=20)
+
+@pytest.mark.asyncio
+async def test_ssl_client_fails_against_plaintext_server(
+    mcache_params: McacheParams
+) -> None:
+        client = Client(**mcache_params, ssl=True)
+        # If SSL was correctly enabled, this should
+        # fail, since SSL isn't enabled on the memcache
+        # server.
+        with pytest.raises(ssl.SSLError):
+            await client.get(b"key")


### PR DESCRIPTION
## What do these changes do?

Adds the possibility to use TLS on the connection to the memcache server.
 
## Are there changes in behavior for the user?

Two new possible params when creating `Client`: `ssl` and `ssl_handshake_timeout`. 

## Related issue number

Resolves #250 

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes
- [ ] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` (e.g. `588.bugfix`)
  * if you don't have an `issue_id` change it to the pr id after creating the PR
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: `Fix issue with non-ascii contents in doctest text files.`
