### PR TITLE
change list comprehension on for loop

### DIFF
--- a/aiomcache/client.py
+++ b/aiomcache/client.py
@@ -135,7 +135,9 @@ class FlagClient(Generic[_T]):
         if not keys:
             return {}, {}
 
-        [self._validate_key(key) for key in keys]
+        for key in keys:
+            self._validate_key(key)
+
         if len(set(keys)) != len(keys):
             raise ClientException('duplicate keys passed to multi_get')
 


### PR DESCRIPTION
There is no need to use list comprehension since your operation does not use this list. so you just create a list and gc automatically deletes it already. 
You can easily verify this with the following example.

```bash
python -m timeit '[i for i in range(10_000_000)]' repeat 5
```

```bash
python -m timeit 'for i in range(10_000_000):' '    ...' repeat 5
```