### PR TITLE
Fix client getting stuck on unexpected server EOF

### DIFF
--- a/aiomcache/client.py
+++ b/aiomcache/client.py
@@ -107,6 +107,11 @@ class FlagClient(Generic[_T]):
 
         while not line.endswith(b'\r\n'):
             line = await conn.reader.readline()
+            if not line:
+                # readline() returns an empty string at EOF.
+                raise ClientException(
+                    'Connection closed by the server before receiving a full response',
+                )
             response.extend(line)
         return response[:-2]
 

--- a/tests/commands_test.py
+++ b/tests/commands_test.py
@@ -362,6 +362,26 @@ async def test_close(mcache: Client) -> None:
     assert mcache._pool.size() == 0
 
 
+async def test_simple_command_server_dies_mid_response() -> None:
+    async def handler(reader: asyncio.StreamReader,
+                      writer: asyncio.StreamWriter) -> None:
+        await reader.readline()
+        writer.write(b"VERSION 1.6.0")  # incomplete line, no \r\n
+        await writer.drain()
+        writer.close()
+
+    server = await asyncio.start_server(handler, "127.0.0.1", 0)
+    port = server.sockets[0].getsockname()[1]
+    client = Client("127.0.0.1", port)
+    try:
+        with pytest.raises(ClientException, match="closed by the server"):
+            await asyncio.wait_for(client.version(), timeout=5)
+    finally:
+        await client.close()
+        server.close()
+        await server.wait_closed()
+
+
 @pytest.mark.parametrize(
     "value",
     [


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

Fix client getting stuck when server closes connection unexpectedly

## Are there changes in behavior for the user?

An exception will be raised in such case instead of getting stuck forever trying to read data

## Related issue number

Fixes https://github.com/aio-libs/aiomcache/issues/502

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [ ] Documentation reflects the changes
